### PR TITLE
Work around setpriv failure

### DIFF
--- a/files/supervisor-secondary.conf
+++ b/files/supervisor-secondary.conf
@@ -37,7 +37,7 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:xroad-proxy]
-command=/usr/bin/setpriv --reuid=xroad --regid=xroad --init-groups --inh-caps=-all,+NET_BIND_SERVICE --ambient-caps=-all,+NET_BIND_SERVICE /usr/share/xroad/bin/xroad-proxy
+command=/files/xroad-proxy-wrapper
 autorestart=true
 stopwaitsecs=30
 stdout_logfile=/dev/stdout

--- a/files/supervisor.conf
+++ b/files/supervisor.conf
@@ -37,7 +37,7 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:xroad-proxy]
-command=/usr/bin/setpriv --reuid=xroad --regid=xroad --init-groups --inh-caps=-all,+NET_BIND_SERVICE --ambient-caps=-all,+NET_BIND_SERVICE /usr/share/xroad/bin/xroad-proxy
+command=/files/xroad-proxy-wrapper
 autorestart=true
 stopwaitsecs=30
 stdout_logfile=/dev/stdout

--- a/files/xroad-proxy-wrapper
+++ b/files/xroad-proxy-wrapper
@@ -5,4 +5,4 @@
 cap_prefix="-cap_"
 caps="$cap_prefix$(seq -s ",$cap_prefix" 0 $(cat /proc/sys/kernel/cap_last_cap))"
 
-/usr/bin/setpriv --reuid=xroad --regid=xroad --init-groups --inh-caps=$caps,+NET_BIND_SERVICE --ambient-caps=$caps,+NET_BIND_SERVICE /usr/share/xroad/bin/xroad-proxy
+exec /usr/bin/setpriv --reuid=xroad --regid=xroad --init-groups --inh-caps=$caps,+NET_BIND_SERVICE --ambient-caps=$caps,+NET_BIND_SERVICE /usr/share/xroad/bin/xroad-proxy

--- a/files/xroad-proxy-wrapper
+++ b/files/xroad-proxy-wrapper
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# WORKAROUND for `setpriv: libcap-ng is too old for "all" caps`, previously "-all" was used here
+# create a list to drop all capabilities supported by current kernel
+cap_prefix="-cap_"
+caps="$cap_prefix$(seq -s ",$cap_prefix" 0 $(cat /proc/sys/kernel/cap_last_cap))"
+
+/usr/bin/setpriv --reuid=xroad --regid=xroad --init-groups --inh-caps=$caps,+NET_BIND_SERVICE --ambient-caps=$caps,+NET_BIND_SERVICE /usr/share/xroad/bin/xroad-proxy


### PR DESCRIPTION
Work around setpriv failure on xroad-proxy startup:
```
 setpriv: libcap-ng is too old for "all" caps
 ```